### PR TITLE
Command to restart the whole server

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,12 @@
 				"category": "Lean 4",
 				"title": "Refresh file dependencies",
 				"description": "Restarts the file worker for the file that is currently focused to refresh the dependencies."
+			},
+			{
+				"command": "lean4.restartServer",
+				"category": "Lean 4",
+				"title": "Restart server",
+				"description": "Restarts the entire language server."
 			}
 		],
 		"keybindings": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "lean4",
 	"description": "An extension for VS Code which provides support for the Lean 4 language.",
 	"license": "MIT",
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/mhuisi/vscode-lean4"


### PR DESCRIPTION
Adds a command to restart the server. It seems to work, but I don't know any Typescript. In particular I'm assuming closures referencing `client` will always see its new version, which they do seem to?